### PR TITLE
chore(command-center): add env property to hide command center feature

### DIFF
--- a/components/Menu.vue
+++ b/components/Menu.vue
@@ -56,6 +56,11 @@
 import { menus, parentMenus } from '~/assets/constant/enum'
 import { isAdmin } from '~/utils'
 export default {
+  data () {
+    return {
+      commandCenter: process.env.featureCommandCenter
+    }
+  },
   computed: {
     menus () {
       const list = menus.filter((menu) => {
@@ -73,10 +78,18 @@ export default {
       const list = parentMenus.filter((menu) => {
         if (this.isAdmin(this.$auth)) {
           if (menu.role.includes('admin_reservasi')) {
-            return menu
+            if (this.commandCenter) {
+              return menu
+            } else {
+              return menu.id === 1
+            }
           }
         } else if (menu.role.includes('employee_reservasi')) {
-          return menu
+          if (this.commandCenter) {
+            return menu
+          } else {
+            return menu.id === 1
+          }
         }
       })
       return list

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,7 @@
 export default {
+  env: {
+    featureCommandCenter: process.env.FEATURE_COMMAND_CENTER === 'true'
+  },
   // Disable server-side rendering (https://go.nuxtjs.dev/ssr-mode)
   ssr: false,
 


### PR DESCRIPTION
### Changes

1. Hide menu command center as Admin roles 

### Preview 
![image](https://user-images.githubusercontent.com/79241754/156732221-3edefadd-ea3d-4d83-9dde-ebe2f31c5c0c.png)

### Evidece
title: chore(command-center): add env property to hide command center feature
project: DigitTeam
participants: @doohanas @maruf12 @naufalihsank @adzharamrullah @maulanayuseph @yoslie 