### PR TITLE
fix(calendar-reservation):  validation end date input and add error message

### DIFF
--- a/components/recurring/mixins/recurringMixins.js
+++ b/components/recurring/mixins/recurringMixins.js
@@ -43,12 +43,10 @@ const recurringMixins = {
       return days.join(', ')
     },
     endDate () {
-      const startDate = this.disabledDates.to
       const dateSplit = this.formEndDate.split('/').reverse().join(', ')
       const endDate = new Date(dateSplit)
       const newEndDate = momentFormatDate(endDate, 'DD/MM/YYYY')
-      const newStartDate = momentFormatDate(startDate, 'DD/MM/YYYY')
-      return endDate < startDate ? newEndDate : newStartDate
+      return newEndDate
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,7 +24,7 @@
               v-model="start_date"
               name="formDateReservation"
               placeholder="Tanggal Akhir"
-              label="Waktu dan Tanggal"
+              label="Waktu dan Tanggal Mulai"
               @input="validateInputTime"
             />
           </div>
@@ -115,6 +115,17 @@
               @change:form-month="reservation.monthly.month = $event"
             />
           </div>
+        </section>
+
+        <!-- Alert -->
+        <section
+          v-if="endDateIsError"
+          class="w-full p-4 bg-red-500 mb-6 flex gap-4 place-items-center"
+        >
+          <i class="bx bx-error-circle bx-sm text-white" aria-hidden="true" />
+          <p class="text-white text-sm">
+            Rentang tanggal tidak valid(tanggal berakhir tidak boleh kurang dari tanggal mulai)
+          </p>
         </section>
 
         <!-- Spaces -->
@@ -489,6 +500,24 @@ export default {
         return typeof value === 'undefined' || value === null
       })
       return isError || isAssetEmpty || isFormEmpty || isRules || !isEmail || isStartDate || isFormTitle || isFormDescription
+    },
+    endDateIsError () {
+      let isError = false
+      switch (this.form.repeat_type) {
+        case 'DAILY':
+          isError = this.endDate !== '' && this.form.end_date <= this.form.date
+          break
+        case 'WEEKLY':
+          isError = this.endDate !== '' && this.form.end_date <= this.form.date
+          break
+        case 'MONTHLY':
+          isError = this.endDate !== '' && this.form.end_date <= this.form.date
+          break
+        default:
+          isError = false
+          break
+      }
+      return isError
     }
   },
   watch: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -460,13 +460,13 @@ export default {
       const { monthly } = this.reservation
       switch (this.form.repeat_type) {
         case 'DAILY':
-          isRules = (!this.formDays.length && !this.form.days.length) || (this.form.end_date <= this.currentDate)
+          isRules = (!this.formDays.length && !this.form.days.length) || (this.form.end_date <= this.form.date)
           break
         case 'WEEKLY':
-          isRules = !this.form.week || this.form.week > 12 || this.form.week <= 0 || /[^0-9]\d*$/.test(this.form.week) || (!this.formDays.length && !this.form.days.length) || (this.form.end_date <= this.currentDate)
+          isRules = !this.form.week || this.form.week > 12 || this.form.week <= 0 || /[^0-9]\d*$/.test(this.form.week) || (!this.formDays.length && !this.form.days.length) || (this.form.end_date <= this.form.date)
           break
         case 'MONTHLY':
-          isRules = typeof monthly.month !== 'number' || !monthly.month || monthly.month >= 4 || monthly.month <= 0 || !Number.isInteger(monthly.month) || (this.form.end_date <= this.currentDate) || !(typeof monthly.week !== 'undefined' && monthly.week !== null) || !(typeof monthly.days[0] !== 'undefined')
+          isRules = typeof monthly.month !== 'number' || !monthly.month || monthly.month >= 4 || monthly.month <= 0 || !Number.isInteger(monthly.month) || (this.form.end_date <= this.form.date) || !(typeof monthly.week !== 'undefined' && monthly.week !== null) || !(typeof monthly.days[0] !== 'undefined')
           break
         default:
           isRules = false
@@ -853,6 +853,7 @@ export default {
         this.form.date = momentFormatDate(toMoment(selectInfo.start, selectInfo.view.calendar).format(this.dateFormat.withoutTime), 'YYYY-MM-DD')
         this.start_date = momentFormatDate(toMoment(selectInfo.start, selectInfo.view.calendar).format(this.dateFormat.withoutTime), 'DD/MM/YYYY')
         this.form.end_date = toMoment(selectInfo.start, selectInfo.view.calendar).format(this.dateFormat.withoutTime)
+        this.endDate = momentFormatDate(toMoment(selectInfo.start, selectInfo.view.calendar).format(this.dateFormat.withoutTime), 'DD/MM/YYYY')
         this.form.repeat_type = 'NONE'
         this.form.week = '1'
         this.form.days = []


### PR DESCRIPTION
### Task

1. https://app.clickup.com/t/2df5j66

### Changes

1. Fix validation end date 
2. Add an error message when the end date is less than the start date

### Preview

1. Fix validation end date
![image](https://user-images.githubusercontent.com/79241754/157626135-28a52c5a-eddf-4b74-a08b-ec2c67b44dc0.png)

2. Add an error message when the end date is less than the start date
![image](https://user-images.githubusercontent.com/79241754/157625912-0e25f308-abd8-4a0f-bc83-c2ca4a18e3f0.png)

### Evidence
title: fix(calendar-reservation): validation end date input and add error message
project: DigiTeam
participants: @doohanas @maulanayuseph @maruf12 @Ibwedagama @adzharamrullah 